### PR TITLE
Remove backgrounds from component cards

### DIFF
--- a/src/components/Event/event.tsx
+++ b/src/components/Event/event.tsx
@@ -21,7 +21,7 @@ export default function Event({
     <Link
       to="/events/$slug"
       params={{ slug }}
-      className="group relative block min-h-[400px] cursor-pointer overflow-hidden rounded-2xl border border-accent-600/20 bg-primary-600 transition-transform active:scale-98 md:min-h-[450px] dark:border-accent-500/20 dark:bg-primary-700"
+      className="group relative block min-h-[400px] cursor-pointer overflow-hidden rounded-2xl border border-accent-600/20 transition-transform active:scale-98 md:min-h-[450px] dark:border-accent-500/20"
     >
       <Image
         src={image.src}
@@ -30,7 +30,7 @@ export default function Event({
         height={image.height}
         className="absolute inset-0 h-full w-full object-cover transition-opacity group-hover:opacity-0"
       />
-      <div className="absolute top-0 left-0 h-full w-full bg-primary-900/60 dark:bg-grey-900/70"></div>
+      <div className="absolute top-0 left-0 h-full w-full bg-primary-900/60"></div>
       <div className="relative z-10 space-y-6 p-8 md:space-y-8">
         <EventStatusChip isPast={isPast} />
         <h3 className="font-display text-3xl text-primary-50 dark:text-grey-100">{title}</h3>

--- a/src/components/EventCardCondensed/event-card-condensed.tsx
+++ b/src/components/EventCardCondensed/event-card-condensed.tsx
@@ -15,7 +15,7 @@ export default function EventCardCondensed({
     <Link
       to="/events/$slug"
       params={{ slug }}
-      className="group relative block overflow-hidden rounded-xl border border-accent-600/20 bg-primary-600 transition-all hover:shadow-md dark:border-accent-500/20 dark:bg-primary-700"
+      className="group relative block overflow-hidden rounded-xl border border-accent-600/20 transition-all hover:shadow-md dark:border-accent-500/20"
     >
       {/* Image background */}
       <div className="relative h-32 w-full overflow-hidden">
@@ -24,12 +24,12 @@ export default function EventCardCondensed({
           alt={image.alt}
           className="absolute inset-0 h-full w-full object-cover transition-transform group-hover:scale-105"
         />
-        <div className="absolute inset-0 bg-primary-900/60 dark:bg-grey-900/70"></div>
+        <div className="absolute inset-0 bg-primary-900/60"></div>
 
         {/* Date badge */}
-        <div className="absolute top-3 right-3 flex items-center gap-2 rounded-lg bg-grey-900/80 px-3 py-1.5 backdrop-blur dark:bg-grey-900/80">
-          <Calendar className="h-4 w-4 stroke-grey-100" />
-          <span className="font-body text-sm font-medium text-grey-100">{fmtDate}</span>
+        <div className="absolute top-3 right-3 flex items-center gap-2 rounded-lg bg-primary-900/80 px-3 py-1.5 backdrop-blur">
+          <Calendar className="h-4 w-4 stroke-primary-100" />
+          <span className="font-body text-sm font-medium text-primary-100">{fmtDate}</span>
         </div>
       </div>
 

--- a/src/components/GetInvolved/get-involved.tsx
+++ b/src/components/GetInvolved/get-involved.tsx
@@ -40,7 +40,7 @@ export default function GetInvolved({
     <div className="px-4 lg:px-0">
       <div className="mx-auto max-w-6xl">
         <motion.div
-          className="overflow-hidden rounded-3xl bg-white shadow-md dark:bg-grey-800"
+          className="overflow-hidden rounded-3xl bg-white shadow-md dark:bg-transparent dark:border dark:border-accent-600/20"
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
@@ -88,7 +88,7 @@ export default function GetInvolved({
                     placeholder="your.email@example.com"
                     required
                     aria-required="true"
-                    className="flex-1 rounded-xl border border-accent-300 bg-white px-4 py-3 font-body text-grey-900 placeholder-grey-500 shadow-sm transition focus:border-accent-600 focus:ring-2 focus:ring-accent-600/20 focus:outline-none dark:border-accent-700 dark:bg-grey-800 dark:text-grey-100 dark:placeholder-grey-400 dark:focus:border-accent-500 dark:focus:ring-accent-500/20"
+                    className="flex-1 rounded-xl border border-accent-300 bg-white px-4 py-3 font-body text-grey-900 placeholder-grey-500 shadow-sm transition focus:border-accent-600 focus:ring-2 focus:ring-accent-600/20 focus:outline-none dark:border-accent-600/30 dark:bg-transparent dark:text-grey-100 dark:placeholder-grey-400 dark:focus:border-accent-500 dark:focus:ring-accent-500/20"
                   />
                   <Button type="submit" variant="accent" size="small">
                     Subscribe
@@ -107,7 +107,7 @@ export default function GetInvolved({
                     target="_blank"
                     rel="noopener noreferrer"
                     aria-label="Follow us on Facebook (opens in new window)"
-                    className="rounded-lg bg-white p-3 shadow-sm transition-all hover:shadow-md focus-visible:ring-2 focus-visible:ring-accent-600 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-95 dark:bg-grey-800"
+                    className="rounded-lg bg-white p-3 shadow-sm transition-all hover:shadow-md focus-visible:ring-2 focus-visible:ring-accent-600 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-95 dark:bg-transparent dark:border dark:border-accent-600/30"
                   >
                     <svg
                       role="img"
@@ -125,7 +125,7 @@ export default function GetInvolved({
                     target="_blank"
                     rel="noopener noreferrer"
                     aria-label="Follow us on Instagram (opens in new window)"
-                    className="rounded-lg bg-white p-3 shadow-sm transition-all hover:shadow-md focus-visible:ring-2 focus-visible:ring-accent-600 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-95 dark:bg-grey-800"
+                    className="rounded-lg bg-white p-3 shadow-sm transition-all hover:shadow-md focus-visible:ring-2 focus-visible:ring-accent-600 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-95 dark:bg-transparent dark:border dark:border-accent-600/30"
                   >
                     <svg
                       role="img"


### PR DESCRIPTION
Replace dark grey backgrounds with transparent or primary color variants to eliminate clash with dark green theme. Changes include:
- Get Involved: transparent background with accent border in dark mode
- Event cards: remove grey overlays, use consistent primary colors
- Input fields and social buttons: transparent backgrounds with subtle borders